### PR TITLE
Document available data types

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -29,7 +29,22 @@ TODO
 
 ### Data Types
 
-TODO
+Data variables must be one of the following data types:
+
+- `string` for text (non-numeric) data
+- `byte` (`int8`), `short` (`int16`), `int` (`int32`), `int64`, and their
+  `unsigned` counterparts, for integer numeric data
+- `float` (`float32`) and `double` (`float64`) for non-integer numeric data
+- `complex64` and `complex128` for complex valued data
+
+**Notes:**
+
+1. NetCDF and HDF5 do not natively support complex data types (unlike Zarr).
+   When using netCDF files we recommend the [`nc-complex`
+   library](https://nc-complex.readthedocs.io/en/latest/) which is integrated with
+   the `netCDF4` python bindings.
+2. The `char` datatype may be used for metadata-only variables, but shouldn't be
+   used to store text. Use the variable length `string` data type instead.
 
 ### Naming Conventions
 


### PR DESCRIPTION
Notable changes compared to [CFConventions](https://cfconventions.org/Data/cf-conventions/cf-conventions-1.12/cf-conventions.html#_data_types):

- `char` is not allowed for text data
- No text encoding is defined (CF indicates to use UTF-8)
  - The IMAS Data Dictionary doesn't indicate anything on text encoding either, probably presuming everything is ASCII text
- Complex valued data types are allowed